### PR TITLE
paxos: add lpcap.c to CPP_FILES

### DIFF
--- a/p4/examples/paxos/Makefile
+++ b/p4/examples/paxos/Makefile
@@ -21,6 +21,7 @@ PINOUT_FILE=$(SONICDIR)/boards/de5.json
 S2H_INTERFACES=ParserTestRequest:ParserTest.request
 H2S_INTERFACES=ParserTest:ParserTestIndication,MemServerIndication
 CPPFILES=test.cpp
+CPPFILES+=$(SONICDIR)/sw/lpcap.c
 BSVFILES=ParserTest.bsv
 FPGAMAKE_CONNECTALFLAGS += -P mkPcieHostTop
 


### PR DESCRIPTION
Hi Han, 

It failed to make paxos example without adding the lpcap.c to the CPP_FILES. I've made the change to build successfully again.